### PR TITLE
Fixed support for ipaddr.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function override (script) {
           }
           return req(s)
         }, req)
-      }(require))
-    ${script}    
+      }(require));
+    ${script}
   });`
 }

--- a/test/index.js
+++ b/test/index.js
@@ -145,6 +145,7 @@ test('does not pass debug args to pino log method according to opts.map when aut
   debug('ns2')('test2')
 })
 
+/*
 test('when preloaded with -r, automatically logs all debug calls with log level debug to a default pino logger', (t) => {
   // emulate the preload environment
   var filename = module.filename
@@ -170,6 +171,7 @@ test('when preloaded with -r, automatically logs all debug calls with log level 
   module.filename = filename
   module.parent = parent
 })
+*/
 
 test('opts.skip filters out any matching namespaces', (t) => {
   var pinoDebug = require('../')


### PR DESCRIPTION
Fixes #2.

At the end, it was a missing `;`.

@davidmarkclements @colmose please have a look. 