### PR TITLE
fix: append newline between script and tail to ensure valid syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function override (script) {
         }, req)
       }(require));
   `.replace(/\n/g, ';').replace(/\s+/g, ' ').replace(/;+/g, ';')
-  var tail = '});'
+  var tail = '\n});'
 
   return head + script + tail
 }

--- a/test/fixtures/trailing-comment.js
+++ b/test/fixtures/trailing-comment.js
@@ -1,0 +1,4 @@
+/* eslint eol-last: off */
+
+module.exports = 1
+// trailing comment

--- a/test/index.js
+++ b/test/index.js
@@ -298,3 +298,8 @@ test('keeps line numbers consistent', (t) => {
 
   t.end()
 })
+
+test('results in valid syntax when source has trailing comment', (t) => {
+  t.doesNotThrow(() => require('./fixtures/trailing-comment'))
+  t.end()
+})


### PR DESCRIPTION
if the last line of the script is a comment, the tail must be written
on a newline to ensure the resulting source is valid syntax