### PR TITLE
Add support for Windows and fix tests for debug module > v2.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,12 @@ function byPrecision (a, b) {
 }
 
 function override (script) {
+  // Escape backslashes to prevent from interpreting backslashes on Windows platform
+  // during expression interpolation in ES6 template literal.
+  // Without this change, Windows path retrieved from require.resolve (eg.
+  // F:\Projekty\Learn\pino-debug\debug.js) will be interpreted during interpolation
+  // as F:ProjektyLearnpino-debugdebug.js and node.js will throw error
+  // Cannot find module 'F:ProjektyLearnpino-debugdebug.js'
   var pathToPinoDebug = require.resolve('./debug').replace(/\\/g, '\\\\')
 
   var head = `(function(exports, require, module, __filename, __dirname) {

--- a/index.js
+++ b/index.js
@@ -17,15 +17,17 @@ function pinoDebug (logger, opts) {
   opts = opts || {}
   var auto = 'auto' in opts ? opts.auto : true
   var map = opts.map || {}
+  var namespaces = []
   debug.map = Object.keys(map).sort(byPrecision).reduce(function (m, k) {
-    if (auto) debug.enable(k)
+    if (auto) namespaces.push(k)
     m.set(RegExp('^' + k.replace(/[\\^$+?.()|[\]{}]/g, '\\$&').replace(/\*/g, '.*?') + '$'), map[k])
     return m
   }, new Map())
   debug.logger = logger || pino({level: 'debug'})
   if (opts.skip) {
-    opts.skip.map(function (ns) { return '-' + ns }).forEach(debug.enable)
+    opts.skip.map(function (ns) { return '-' + ns }).forEach(function (ns) { namespaces.push(ns) })
   }
+  debug.enable(namespaces.join(','))
 }
 
 function byPrecision (a, b) {

--- a/index.js
+++ b/index.js
@@ -43,11 +43,8 @@ function byPrecision (a, b) {
 }
 
 function override (script) {
-  var pathToPinoDebug = require.resolve('./debug')
+  var pathToPinoDebug = require.resolve('./debug').replace(/\\/g, '/')
 
-  if (process.platform === 'win32') {
-    pathToPinoDebug = pathToPinoDebug.replace(/\\/g, '/')
-  }
   var head = `(function(exports, require, module, __filename, __dirname) {
       require = (function (req) {
         var Object = ({}).constructor

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function byPrecision (a, b) {
 }
 
 function override (script) {
-  var pathToPinoDebug = require.resolve('./debug').replace(/\\/g, '/')
+  var pathToPinoDebug = require.resolve('./debug').replace(/\\/g, '\\\\')
 
   var head = `(function(exports, require, module, __filename, __dirname) {
       require = (function (req) {

--- a/index.js
+++ b/index.js
@@ -41,12 +41,24 @@ function byPrecision (a, b) {
 }
 
 function override (script) {
+  var pathToPinoDebug = require.resolve('./debug')
+
+  if (process.platform === 'win32') {
+    pathToPinoDebug = pathToPinoDebug.replace(/\\/g, '/')
+  }
   var head = `(function(exports, require, module, __filename, __dirname) {
       require = (function (req) {
         var Object = ({}).constructor
-        return Object.setPrototypeOf(function pinoDebugWrappedRequire(s) {
-          if (s === './debug' && /node_modules\\/debug/.test(__dirname.slice(-22))) {
-            var dbg = req('${require.resolve('./debug')}')
+        return Object.setPrototypeOf(function pinoDebugWrappedRequire(s) {        
+          var dirname = __dirname.slice(-22)
+          var pathToPinoDebug = '${pathToPinoDebug}'
+                    
+          if (process.platform === 'win32') {
+              dirname = dirname.replace(/\\\\/g, '/')
+          }
+          
+          if (s === './debug' && /node_modules\\/debug/.test(dirname)) {
+            var dbg = req(pathToPinoDebug)
             var real = req(s)
             Object.assign(dbg, real)
             Object.defineProperty(real, 'save', {get: function () {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "debug": "2.6.0",
+    "debug": "^2.6.9",
     "pino": "^4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

Recently I bough a book [Node Cookbook - Third Edition](https://www.packtpub.com/web-development/node-cookbook-third-edition)  where I first heard about the `pino-debug` module.

Really nice module!

Unfortunately after setting `DEBUG=*`  and running simple app from book (simple express app)  I saw only standard logs from express app without any bugs from `pino-debug` or output formatted by `pino-debug`.

I run examples on my Windows machine, and after I dig little into `pino-module`  I found problem in the method `override` which override standard wrap method.

The problem was with path characters where on Windows machine this test `/node_modules\\/debug/.test(__dirname.slice(-22))` was `false`, because in Windows path looks like this `node_modules\debug`. Similar problem with path was with getting absolute path to inner debug module `require.resolve('./debug')`. So with this PR I propose fix to this problem.

Additionally with this PR I introduce a change in `pinoDebug` method witch fix tests (#4) for `debug` module version > 2.6.1.

I hope you don't mind that I made one PR for those changes, probably it would be better if I prepare two separate PR's for those changes, but at first I prepare separate branch for changes for Windows but after that I merge those changes into branch with changes to tests.

> I cannot run directly `npm scripts` because with current approach, those scripts doesn't work on Windows, If it will be no problem for you I can prepare change to include [cross-env](https://www.npmjs.com/package/cross-env) module, to prepare `npm scripts` to run on all platforms.


Regards,
Łukasz