### PR TITLE
Add cross-env to run npm scripts across platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "main": "index.js",
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev",
-    "test": "standard && dependency-check . && NODE_ENV=test tap test/*.js",
+    "test": "standard && dependency-check . && cross-env NODE_ENV=test tap test/*.js",
     "test-2.3": "npm i debug@2.3 && npm run test",
     "test-2.4": "npm i debug@2.4 && npm run test",
     "test-2.5": "npm i debug@2.5 && npm run test",
     "test-2.6": "npm i debug@2.6 && npm run test",
-    "test:cov": "standard && npm run deps && NODE_ENV=test tap --cov test/*.js",
+    "test:cov": "standard && npm run deps && cross-env NODE_ENV=test tap --cov test/*.js",
     "ci": "npm test -- --coverage-report=lcov",
-    "test:cov:html": "standard && npm run deps && NODE_ENV=test tap --coverage-report=html test",
+    "test:cov:html": "standard && npm run deps && cross-env NODE_ENV=test tap --coverage-report=html test",
     "bench": "node benchmarks/runbench all",
     "bench-basic": "node benchmarks/runbench basic",
     "bench-object": "node benchmarks/runbench object",
@@ -34,6 +34,7 @@
     "pino": "^4.0.2"
   },
   "devDependencies": {
+    "cross-env": "^5.1.1",
     "dependency-check": "^2.6.0",
     "fastbench": "^1.0.1",
     "flush-write-stream": "^1.0.2",


### PR DESCRIPTION
Hi,

As I mention earlier, this is PR for enabling `npm scripts` to run correctly on Windows platform, thanks to `cross-env` package.

Regards,
Łukasz