### PR TITLE
Making pino-debug compatible with debug v3

### DIFF
--- a/benchmarks/basic.bench.js
+++ b/benchmarks/basic.bench.js
@@ -3,7 +3,7 @@ var wrap = require('module').wrap
 var bench = require('fastbench')
 var pino = require('pino')
 var fs = require('fs')
-var dest = fs.createWriteStream('/dev/null')
+var dest = process.platform === 'win32' ? fs.createWriteStream('\\\\.\\NUL') : fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 
 process.env.DEBUG = 'dlog'

--- a/benchmarks/deep-object.bench.js
+++ b/benchmarks/deep-object.bench.js
@@ -3,7 +3,7 @@ var wrap = require('module').wrap
 var bench = require('fastbench')
 var pino = require('pino')
 var fs = require('fs')
-var dest = fs.createWriteStream('/dev/null')
+var dest = process.platform === 'win32' ? fs.createWriteStream('\\\\.\\NUL') : fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 
 process.env.DEBUG = 'dlog'

--- a/benchmarks/object.bench.js
+++ b/benchmarks/object.bench.js
@@ -3,7 +3,7 @@ var wrap = require('module').wrap
 var bench = require('fastbench')
 var pino = require('pino')
 var fs = require('fs')
-var dest = fs.createWriteStream('/dev/null')
+var dest = process.platform === 'win32' ? fs.createWriteStream('\\\\.\\NUL') : fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 
 process.env.DEBUG = 'dlog'

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "body-parser": "~1.15.2",
     "cookie-parser": "~1.4.3",
-    "debug": "^2.6.1",
+    "debug": "^3.1.0",
     "express": "~4.14.0",
     "jade": "~1.11.0",
     "morgan": "~1.7.0"

--- a/example/package.json
+++ b/example/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "start": "node ./bin/www",
     "start-preload": "DEBUG=* node -r ../ ./bin/www",
-    "start-programmatic": "./bin/www-programmatic",
-    "start-programmatic-debug": "LEVEL=debug ./bin/www-programmatic",
-    "start-programmatic-trace": "LEVEL=trace ./bin/www-programmatic"
+    "start-programmatic": "node ./bin/www-programmatic",
+    "start-programmatic-debug": "LEVEL=debug node ./bin/www-programmatic",
+    "start-programmatic-trace": "LEVEL=trace node ./bin/www-programmatic"
   },
   "dependencies": {
     "body-parser": "~1.15.2",

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function pinoDebug (logger, opts) {
   opts = opts || {}
   var auto = 'auto' in opts ? opts.auto : true
   var map = opts.map || {}
-  var namespaces = []
+  var namespaces = getNamespaces()
   debug.map = Object.keys(map).sort(byPrecision).reduce(function (m, k) {
     if (auto) namespaces.push(k)
     m.set(RegExp('^' + k.replace(/[\\^$+?.()|[\]{}]/g, '\\$&').replace(/\*/g, '.*?') + '$'), map[k])
@@ -28,6 +28,14 @@ function pinoDebug (logger, opts) {
     opts.skip.map(function (ns) { return '-' + ns }).forEach(function (ns) { namespaces.push(ns) })
   }
   debug.enable(namespaces.join(','))
+}
+
+function getNamespaces () {
+  var namespaces = process.env.DEBUG
+  if (namespaces != null) {
+    return (typeof namespaces === 'string' ? namespaces : '').split(/[\s,]+/)
+  }
+  return []
 }
 
 function byPrecision (a, b) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "debug": "^2.6.9",
+    "debug": "^3.1.0",
     "pino": "^4.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test-2.4": "npm i debug@2.4 && npm run test",
     "test-2.5": "npm i debug@2.5 && npm run test",
     "test-2.6": "npm i debug@2.6 && npm run test",
+    "test-3.1": "npm i debug@3.1 && npm run test",
     "test:cov": "standard && npm run deps && NODE_ENV=test tap --cov test/*.js",
     "ci": "npm test -- --coverage-report=lcov",
     "test:cov:html": "standard && npm run deps && NODE_ENV=test tap --coverage-report=html test",

--- a/test/index.js
+++ b/test/index.js
@@ -304,7 +304,7 @@ test('results in valid syntax when source has trailing comment', (t) => {
   t.end()
 })
 
-test('Set env.DEBUG and captures any calls to `debug` and passes them through pino logger', (t) => {
+test('preserves DEBUG env independently from debug module', (t) => {
   process.env.DEBUG = 'ns1'
   var pinoDebug = require('../')
   var stream = through((line, _, cb) => {

--- a/test/index.js
+++ b/test/index.js
@@ -303,3 +303,17 @@ test('results in valid syntax when source has trailing comment', (t) => {
   t.doesNotThrow(() => require('./fixtures/trailing-comment'))
   t.end()
 })
+
+test('Set env.DEBUG and captures any calls to `debug` and passes them through pino logger', (t) => {
+  process.env.DEBUG = 'ns1'
+  var pinoDebug = require('../')
+  var stream = through((line, _, cb) => {
+    var obj = JSON.parse(line)
+    t.is(obj.msg, 'test')
+    t.is(obj.ns, 'ns1')
+    t.end()
+  })
+  pinoDebug(require('pino')({level: 'debug'}, stream))
+  var debug = require('debug')
+  debug('ns1')('test')
+})

--- a/test/index.js
+++ b/test/index.js
@@ -162,7 +162,6 @@ test('does not pass debug args to pino log method according to opts.map when aut
   debug('ns2')('test2')
 })
 
-/*
 test('when preloaded with -r, automatically logs all debug calls with log level debug to a default pino logger', (t) => {
   // emulate the preload environment
   var filename = module.filename
@@ -188,7 +187,6 @@ test('when preloaded with -r, automatically logs all debug calls with log level 
   module.filename = filename
   module.parent = parent
 })
-*/
 
 test('opts.skip filters out any matching namespaces', (t) => {
   var pinoDebug = require('../')


### PR DESCRIPTION
Hi @davidmarkclements ,

So this is my first try to make pino-debug compatible with debug v3. 

I need to fix situation when someone add namespaces to debug on `process.env.DEBUG` and after running `pino-debug` those namespaces was erased, because of the debug package behavior which erases any previous namespaces after call to `debug.enable` method. This why I add one new test to test this situation, and add new method `getNamespaces` which retrive namespaces from `process.env.DEBUG`.

Because **debug package** erases previous namespaces I put logic into `pinoDebug` method to collect all namespaces ( to enable and disable) and run only once `debug.enable` method.

I had problem with running `npm run bench` script for becnhamrk. After running it I receive this response:

```
> pino-debug@1.0.5 bench /home/node/pino
> node benchmarks/runbench all

Running BASIC benchmark

Running OBJECT benchmark

Running DEEPOBJECT benchmark

==========
basic averages
==========
==========
object averages
==========
==========
deepobject averages
==========
```

Without any errors or results, I even make this test on the master branch without mine changes, and the result is the same. So is this a correct situation?

Regards,
Łukasz