### PR TITLE
bench fix

### DIFF
--- a/benchmarks/basic.bench.js
+++ b/benchmarks/basic.bench.js
@@ -11,8 +11,8 @@ var dlog = require('debug')('dlog')
 dlog.log = function (s) { dest.write(s) }
 
 delete require.cache[require.resolve('debug')]
-delete require.cache[require.resolve('debug/debug.js')]
-delete require.cache[require.resolve('debug/node')]
+delete require.cache[require.resolve('debug/src/debug.js')]
+delete require.cache[require.resolve('debug/src/node')]
 
 delete require.cache[require.resolve('pino')]
 pino = require('pino')
@@ -20,8 +20,8 @@ require('../')(pino({level: 'debug'}, dest))
 var pdlog = require('debug')('dlog')
 
 delete require.cache[require.resolve('debug')]
-delete require.cache[require.resolve('debug/debug.js')]
-delete require.cache[require.resolve('debug/node')]
+delete require.cache[require.resolve('debug/src/debug.js')]
+delete require.cache[require.resolve('debug/src/node')]
 delete require.cache[require.resolve('../')]
 delete require.cache[require.resolve('../debug')]
 require('module').wrap = wrap

--- a/benchmarks/deep-object.bench.js
+++ b/benchmarks/deep-object.bench.js
@@ -11,8 +11,8 @@ var dlog = require('debug')('dlog')
 dlog.log = function (s) { dest.write(s) }
 
 delete require.cache[require.resolve('debug')]
-delete require.cache[require.resolve('debug/debug.js')]
-delete require.cache[require.resolve('debug/node')]
+delete require.cache[require.resolve('debug/src/debug.js')]
+delete require.cache[require.resolve('debug/src/node')]
 
 delete require.cache[require.resolve('pino')]
 pino = require('pino')
@@ -20,8 +20,8 @@ require('../')(pino({level: 'debug'}, dest))
 var pdlog = require('debug')('dlog')
 
 delete require.cache[require.resolve('debug')]
-delete require.cache[require.resolve('debug/debug.js')]
-delete require.cache[require.resolve('debug/node')]
+delete require.cache[require.resolve('debug/src/debug.js')]
+delete require.cache[require.resolve('debug/src/node')]
 delete require.cache[require.resolve('../')]
 delete require.cache[require.resolve('../debug')]
 require('module').wrap = wrap

--- a/benchmarks/object.bench.js
+++ b/benchmarks/object.bench.js
@@ -11,8 +11,8 @@ var dlog = require('debug')('dlog')
 dlog.log = function (s) { dest.write(s) }
 
 delete require.cache[require.resolve('debug')]
-delete require.cache[require.resolve('debug/debug.js')]
-delete require.cache[require.resolve('debug/node')]
+delete require.cache[require.resolve('debug/src/debug.js')]
+delete require.cache[require.resolve('debug/src/node')]
 
 delete require.cache[require.resolve('pino')]
 pino = require('pino')
@@ -20,8 +20,8 @@ require('../')(pino({level: 'debug'}, dest))
 var pdlog = require('debug')('dlog')
 
 delete require.cache[require.resolve('debug')]
-delete require.cache[require.resolve('debug/debug.js')]
-delete require.cache[require.resolve('debug/node')]
+delete require.cache[require.resolve('debug/src/debug.js')]
+delete require.cache[require.resolve('debug/src/node')]
 delete require.cache[require.resolve('../')]
 delete require.cache[require.resolve('../debug')]
 require('module').wrap = wrap


### PR DESCRIPTION
the `debug` module structure changed somewhere along the way,
we need to know that structure to clear certain debug files from the require cache
so they can be reinitialized between bench runs 