### PR TITLE
Make sure wrapper doesn't invalidate strict mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 node_js:
-- "4"
-- "6"
-- "8"
 - "10"
+- "12"
+- "14"
 env:
 - DEBUG_VERSION=2
 - DEBUG_VERSION=3
 - DEBUG_VERSION=4
-matrix:
-  exclude:
-  - node_js: "4"
-    env: DEBUG_VERSION=4
 sudo: false
 language: node_js
 script:

--- a/index.js
+++ b/index.js
@@ -96,9 +96,10 @@ function override (script) {
           }
           return req(s)
         }, req)
-      }(require));
-  `.replace(/\n/g, ';').replace(/\s+/g, ' ').replace(/;+/g, ';')
-  var tail = '\n});'
+      }(require))
+      return (function(){
+  `.trim().replace(/\n/g, ';').replace(/\s+/g, ' ').replace(/;+/g, ';')
+  var tail = '\n}).call(this);})'
 
   return head + script + tail
 }

--- a/test/fixtures/strict-mode.js
+++ b/test/fixtures/strict-mode.js
@@ -1,0 +1,6 @@
+'use strict'
+
+eval('var test = 123')
+
+// This will evaluate to `true` if strict mode is enabled
+module.exports = typeof test === 'undefined'

--- a/test/index.js
+++ b/test/index.js
@@ -337,3 +337,8 @@ test('supports extend method', (t) => {
   debug('ns1').extend('ns2', ';')('test')
   stream.end()
 })
+
+test('does not invalidate strict mode', (t) => {
+  t.is(require('./fixtures/strict-mode'), true)
+  t.end()
+})


### PR DESCRIPTION
The overridden module wrapper that decorates the `require` function adds an assignment statement before the module script itself. If that module starts with the `"use strict"` directive, that needs to be at the very top of the function to have any effect. The injected assignment invalidates that.

This led to a particularly weird bug initially reported to Axios here: axios/axios#3470

The solution is to wrap the module's script into another IIFE.

Note however that this changes the semantics in another way: it adds a stack frame to all modules. This _could_ be an issue if someone is doing something funky with `new Error().stack`.