### PR TITLE
Update pino to v7. Drop node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [10, 12, 14, 15, 16]
+        node-version: [12, 14, 15, 16]
         debug: [2, 3, 4]
     steps:
       - name: Checkout    

--- a/benchmarks/basic.bench.js
+++ b/benchmarks/basic.bench.js
@@ -28,7 +28,7 @@ require('module').wrap = wrap
 
 delete require.cache[require.resolve('pino')]
 pino = require('pino')
-require('../')(pino({extreme: true, level: 'debug'}, dest))
+require('../')(pino({level: 'debug'}, dest))
 var pedlog = require('debug')('dlog')
 
 var max = 10

--- a/benchmarks/deep-object.bench.js
+++ b/benchmarks/deep-object.bench.js
@@ -28,7 +28,7 @@ require('module').wrap = wrap
 
 delete require.cache[require.resolve('pino')]
 pino = require('pino')
-require('../')(pino({extreme: true, level: 'debug'}, dest))
+require('../')(pino({level: 'debug'}, dest))
 var pedlog = require('debug')('dlog')
 
 var deep = require('../package.json')

--- a/benchmarks/object.bench.js
+++ b/benchmarks/object.bench.js
@@ -26,7 +26,7 @@ delete require.cache[require.resolve('../')]
 delete require.cache[require.resolve('../debug')]
 require('module').wrap = wrap
 
-require('../')(pino({extreme: true, level: 'debug'}, dest))
+require('../')(pino({level: 'debug'}, dest))
 var pedlog = require('debug')('dlog')
 
 var max = 10

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "pino": "^6.0.2"
+    "pino": "^7.6.2"
   },
   "peerDependencies": {
     "debug": ">=2"


### PR DESCRIPTION
Resolves #61. Node 10 support is dropped as pino 7 no longer supports it and fails because `worker_threads` are required as seen by failures in #81
