### PR TITLE
chore(debug): missing space in string concat

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -4,7 +4,7 @@ module.exports = debug
 
 function debug (namespace) {
   if (!debug.logger) {
-    throw Error('debug called before pino-debug initialized,' +
+    throw Error('debug called before pino-debug initialized, ' +
    'register pino-debug at the top of your entry point')
   }
 


### PR DESCRIPTION
Text in error thrown appears like so without a space: "debug called before pino-debug initialized,register pino-debug at the top of your entry point"