### PR TITLE
style(examples/bin): explicitly declare semicolon

### DIFF
--- a/example/bin/www-programmatic
+++ b/example/bin/www-programmatic
@@ -5,7 +5,7 @@
  */
 
 
-var pinoDebug = require('../../') // require('pino-debug')
+var pinoDebug = require('../../'); // require('pino-debug')
 const logger = require('pino')({level: process.env.LEVEL || 'debug'}, process.stderr);
 pinoDebug(logger, {
   auto: true, // default


### PR DESCRIPTION
Every other line in this file has an explicit semicolon.
This will stop all of the static analysis tools from crying about it.