### PR TITLE
Process all arguments debug.js style

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var util = require('util');
+
 module.exports = debug
 
 function debug (namespace) {
@@ -16,7 +18,10 @@ function debug (namespace) {
   function disabled () {}
   disabled.enabled = false
   function enabled () {
-    return log.apply(logger, arguments)
+    //return log.apply(logger, arguments)
+
+    let message = util.format.apply(util, arguments) // this is how debug.js formats argeuments
+    return log.apply(logger, [message])
   }
   enabled.enabled = true
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,8 @@
 var execSync = require('child_process').execSync
 var tap = require('tap')
 var through = require('through2')
+const pinoDebug = require("../index");
+const debug = require("debug");
 var test = tap.test
 
 const debugModules = [
@@ -341,4 +343,21 @@ test('supports extend method', (t) => {
 test('does not invalidate strict mode', (t) => {
   t.is(require('./fixtures/strict-mode'), true)
   t.end()
+})
+
+test('Process all arguments debug.js style', (t) => {
+  var testOptions={"option1":"value1"};
+  process.env.DEBUG = 'ns1'
+  var pinoDebug = require('../')
+  var stream = through((line, _, cb) => {
+    var obj = JSON.parse(line)
+    var expectedMsg = "test { option1: 'value1' }";
+    t.is(obj.msg, expectedMsg)
+    t.is(obj.ns, 'ns1')
+    t.end()
+  })
+  pinoDebug(require('pino')({level: 'debug'}, stream))
+  var debug = require('debug')
+
+  debug('ns1')('test', testOptions)
 })


### PR DESCRIPTION
In case of multiple log arguments

`debug("Redis options", options);`

native debug.js produces

`
package:server Redis options {
  host: 'redis.dev.aaa.io',
  port: '6379',
  password: 'some,
  no_ready_check: true,
  tls: { checkServerIdentity: [Function: checkServerIdentity] }
}
`

So it appends all arguments

But in pino-debug it doesn't happen

What happens is just

`
{"level":"debug","time":1710872452769,"ns":"oauth2-authorizer:server","msg":"Redis options"}
`